### PR TITLE
main: improvement - skip overwrite of './ict.cfg' file on every start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ gradle/
 settings.gradle
 gradlew.bat
 gradlew
+ict.ipr
+ict.iws

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cd Desktop/ict/
 java -jar ict-{VERSION}.jar
 ```
 
-On the very first start, this will create a configuration file (**ict.cfg**). Restart your Ict after modifying the configuration.
+Use `--config-create` option to create a configuration file (**ict.cfg**). Restart your Ict after modifying the configuration.
 
 ### Arguments
 
@@ -54,7 +54,9 @@ You can pass the following arguments to the .jar file when running it.
 
 Argument|Alias|Example|Description
 ---|---|---|---
-`-config`|`-c`|`-config ict.cfg`|Loads the Ict configuration from the specified file.
+`--config`|`-c`|`--config ict.cfg`|Loads the Ict configuration from the specified file.
+`--config-print`| |`--config-print`|Print the Ict configuration to stdout and exit.
+`--config-create`| |`--config-create`|Write the Ict configuration './ict.cfg'.
 
 ## IXI Modules
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'idea'
 }
 
 group 'org.iota'

--- a/src/main/java/org/iota/ict/Main.java
+++ b/src/main/java/org/iota/ict/Main.java
@@ -7,52 +7,253 @@ import org.iota.ict.utils.ErrorHandler;
 import org.iota.ict.utils.Properties;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.net.BindException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.util.HashMap;
-import java.util.Map;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 
 /**
- * This class controls what happens when the program is run by a user. It is the entry point when starting this application
- * and helps the user to set up a new Ict node. As such it is a convenience and not technically required to create Ict nodes.
- * A good example are the jUnit tests which work entirely independently from this class.
+ * This class controls what happens when the program is run by a user. It is the entry point when starting this application and helps the user to set up a new
+ * Ict node. As such it is a convenience and not technically required to create Ict nodes. A good example are the jUnit tests which work entirely independently
+ * from this class.
  */
 public class Main {
-
     private static final String DEFAULT_PROPERTY_FILE_PATH = "ict.cfg";
-    private static final File DEFAULT_LOG_DIR = new File("logs/");
+    public static final String DEFAULT_LOG_DIR_PATH = "logs/";
+    private static final File DEFAULT_LOG_DIR = new File(DEFAULT_LOG_DIR_PATH);
+    private static final boolean FAIL_IF_LOG_DIR_NOT_EXIST = false;
 
-    private static final Map<String, String> ARG_NAME_BY_ARG_ALIAS = new HashMap<>();
+    /* Simple {@code ict}-cmdline parser to get a valid {@code ict.Properties} instance */
+    final static class Cmdline {
+        private static String HELP = ""
+                + "# Usage: ict [OPTIONS]" + "\n"
+                + "" + "\n"
+                + "  Start a 'ict' instance by config." + "\n"
+                + "" + "\n"
+                + "# Options" + "\n"
+                + "--help|-h           Print this help and exit" + "\n"
+                + "--config|-c FILE    Use this config 'FILE' (default: ./ict.cfg;if-exist)" + "\n"
+                + "                    - lookup first on environment for uppercase property keys" + "\n"
+                + "                    - and as last in system properties" + "\n"
+                + "--config-create     Create or overwrite './ict.cfg' file with parsed config" + "\n"
+                + "--config-print      Print parsed config and exit" + "\n"
+                + "" + "\n"
+                + "--log-dir DIR       Write logs to existing DIR (default: logs/;currently unused)" + "\n"
+                + "" + "\n"
+                + "# Sample" + "\n"
+                + "$ict --config-print                   # print out config" + "\n"
+                + "$ict --config my-ict.cfg              # use my config" + "\n"
+                + "$ict --config my-ict.cfg  -Dport=1234 # use my config but with port=1234" + "\n"
+                + "$PORT=1234 && ict --config my-ict.cfg # use my config with port=1234 if not declared" + "\n"
+                + "";
+
+        private static final String ARG_CONFIG = "--config";
+        private static final String ARG_CONFIG_SHORT = "-c";
+        private static final String ARG_CONFIG_CREATE = "--config-create";
+        private static final String ARG_CONFIG_PRINT = "--config-print";
+        private static final String ARG_LOG_DIR = "--log-dir";
+        private static final String ARG_HELP = "--help";
+        private static final String ARG_HELP_SHORT = "-h";
+
+        // Different properties configuration layers
+        private final java.util.Properties hardcodedProperties = new Properties().toPropObject();
+        private final java.util.Properties envProperties = new java.util.Properties();
+        private final java.util.Properties defaultConfigProperties = new java.util.Properties();
+        private final java.util.Properties configFileProperties = new java.util.Properties();
+        private final java.util.Properties sysProperties = new java.util.Properties();
+
+        // The cmdline options
+        private boolean isHelp = false;
+        private boolean isCreateConfig = false;
+        private boolean isPrintConfig = false;
+        private String logDir = DEFAULT_LOG_DIR_PATH;
+
+        Cmdline() {/* prevent external construction */}
+
+        /**
+         * Parse the given cmdline args to init this.
+         *
+         * @param args not null arguments
+         */
+        public Cmdline parse(String[] args) {
+            Objects.requireNonNull(args, "'args' must not be null.");
+
+            isHelp = existArgument(args, ARG_HELP, ARG_HELP_SHORT);
+            isCreateConfig = existArgument(args, ARG_CONFIG_CREATE);
+            isPrintConfig = existArgument(args, ARG_CONFIG_PRINT);
+
+            String logDirOrNull = parseValueOrNull(args, ARG_LOG_DIR);
+            logDir = logDirOrNull != null ? logDirOrNull : DEFAULT_LOG_DIR_PATH;
+            if (!Files.exists(Paths.get(logDir)) && FAIL_IF_LOG_DIR_NOT_EXIST) {
+                throw new IllegalArgumentException("Configured log dir '" + logDir + "' not exist.");
+            }
+
+            String configFileOrNull = parseValueOrNull(args, ARG_CONFIG, ARG_CONFIG_SHORT);
+            if (configFileOrNull != null) {
+                try {
+                    configFileProperties.load(new FileInputStream(configFileOrNull));
+                } catch (IOException e) {
+                    throw new IllegalArgumentException("Error while loading of ict config file '" + configFileOrNull + "'", e);
+                }
+            }
+            return this;
+        }
+
+        /**
+         * Create a {@link Properties} instance by using of different property configuration layers (environment, file, system).
+         *
+         * @return an valid instance or fail
+         * @see #useEnvironmentProperties()
+         * @see #useDefaultConfigFile()
+         * @see #useSystemProperties()
+         */
+        public Properties getIctProperties() {
+            java.util.Properties properties = new java.util.Properties();
+            for (Properties.Property property : Properties.Property.values()) {
+                String key = property.name();
+                String value = null;
+
+                if (hardcodedProperties.containsKey(key)) {
+                    value = hardcodedProperties.getProperty(key);
+                }
+
+                if (envProperties.containsKey(key)) {
+                    value = envProperties.getProperty(key);
+                }
+
+                if (defaultConfigProperties.containsKey(key)) {
+                    value = defaultConfigProperties.getProperty(key);
+                }
+
+                if (configFileProperties.containsKey(key)) {
+                    value = configFileProperties.getProperty(key);
+                }
+
+                if (sysProperties.containsKey(key)) {
+                    value = sysProperties.getProperty(key);
+                }
+
+                Objects.requireNonNull(value, "'" + key + "' must be set via environment, config file or system property");
+                properties.put(key, value);
+            }
+            return Properties.fromJavaProperties(properties);
+        }
+
+        /**
+         * Try to read all {@link org.iota.ict.utils.Properties.Property} from {@code system properties}. Ignore not existing property keys.
+         */
+        public Cmdline useSystemProperties() {
+            try {
+                sysProperties.putAll(Properties.fromSystemProperties());
+            } catch (Exception e) {
+                throw new RuntimeException("Error while loading of ict system properties.", e);
+            }
+            return this;
+        }
+
+        /**
+         * Try to read all {@link org.iota.ict.utils.Properties.Property} from {@code environment}. Looking for {@code upper case} keys only. Ignore not
+         * existing one.
+         */
+        public Cmdline useEnvironmentProperties() {
+            try {
+                envProperties.putAll(Properties.fromEnvironment());
+            } catch (Exception e) {
+                throw new RuntimeException("Error while loading of ict environment properties.", e);
+            }
+            return this;
+        }
+
+        /**
+         * Try to read all {@link org.iota.ict.utils.Properties.Property} from default config file {@link #DEFAULT_PROPERTY_FILE_PATH}. Ignore not existing
+         * files. But fail if no read permission exist.
+         */
+        public Cmdline useDefaultConfigFile() {
+            if (Files.exists(Paths.get(DEFAULT_PROPERTY_FILE_PATH))) {
+                try {
+                    defaultConfigProperties.load(new FileInputStream(DEFAULT_PROPERTY_FILE_PATH));
+                } catch (Exception e) {
+                    throw new RuntimeException("Error while loading of ict default config properties.", e);
+                }
+            }
+            return this;
+        }
+
+        private boolean existArgument(String[] args, String... argsFilter) {
+            List<String> argsList = Arrays.asList(args);
+            for (String arg : argsFilter) {
+                if (argsList.contains(arg)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+
+        private String parseValueOrNull(String[] args, String... argsFilter) {
+            for (int index = 0; index < args.length; index++) {
+                String currentArg = args[index];
+                for (String argFilter : argsFilter) {
+                    if (currentArg.equals(argFilter)) {
+                        int nextIndex = index + 1;
+                        if (nextIndex < args.length) {
+                            String argValue = args[nextIndex];
+                            return argValue;
+                        } else {
+                            throw new IllegalArgumentException("No argument value exist for key '" + argFilter + "'");
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+
+
+    }
 
     private static final Logger logger = LogManager.getLogger(Main.class);
 
-    public static final String ARG_CONFIG = "-config";
-
-    static {
-        ARG_NAME_BY_ARG_ALIAS.put("-c", ARG_CONFIG);
-        ARG_NAME_BY_ARG_ALIAS.put(ARG_CONFIG, ARG_CONFIG);
-        Constants.TESTING = false;
-    }
-
     public static void main(String[] args) {
-
         System.out.println(Constants.TRANSACTION_SIZE_TRYTES);
-        Map<String, String> argMap = mapArgs(args);
 
-        Properties properties = loadOrCreatedProperties(argMap);
-        properties.store(argMap.containsKey(ARG_CONFIG) ? argMap.get(ARG_CONFIG) : DEFAULT_PROPERTY_FILE_PATH);
+        Cmdline cmdline = new Cmdline()
+                .useEnvironmentProperties()
+                .useDefaultConfigFile()
+                .useSystemProperties();
 
-        if(properties.roundDuration < 30000 && properties.spamEnabled) {
-            logger.warn("Disabling spam because of low round duration.");
-            properties.spamEnabled = false;
+        cmdline.parse(args);
+
+        if (cmdline.isHelp) {
+            System.out.println(Cmdline.HELP);
+            System.exit(0);
         }
 
-        logger.info("Starting new Ict '" + properties.name + "' (version: " + Constants.ICT_VERSION + ")");
+        Properties ictProperties = cmdline.getIctProperties();
+
+        if (cmdline.isCreateConfig) {
+            ictProperties.store(DEFAULT_PROPERTY_FILE_PATH);
+        }
+
+        if (cmdline.isPrintConfig) {
+            System.out.println(ictProperties.toPropObject().toString().replace(", ", ",\n "));
+            System.exit(0);
+        }
+
+
+        if (ictProperties.roundDuration < 30000 && ictProperties.spamEnabled) {
+            logger.warn("Disabling spam because of low round duration.");
+            ictProperties.spamEnabled = false;
+        }
+
+        logger.info("Starting new Ict '" + ictProperties.name + "' (version: " + Constants.ICT_VERSION + ")");
 
         Ict ict;
         try {
-            ict = new Ict(properties);
+            ict = new Ict(ictProperties);
         } catch (Throwable t) {
             if (t.getCause() instanceof BindException) {
                 ErrorHandler.handleError(logger, t, "\"Could not start Ict on \" + properties.host + \":\" + properties.port.");
@@ -72,49 +273,5 @@ public class Main {
                 finalRefToIct.terminate();
             }
         });
-    }
-
-    private static Properties loadOrCreatedProperties(Map<String, String> argMap) {
-        Properties properties = new Properties();
-        try {
-            properties = tryToLoadOrCreateProperties(argMap);
-        } catch (Throwable t) {
-            ErrorHandler.handleError(logger, t, "Failed loading properties");
-        }
-        return properties;
-    }
-
-    private static Properties tryToLoadOrCreateProperties(Map<String, String> argMap) {
-        if (argMap.containsKey(ARG_CONFIG)) {
-            return Properties.fromFile(argMap.get(ARG_CONFIG));
-        } else if (new File(DEFAULT_PROPERTY_FILE_PATH).exists()) {
-            return Properties.fromFile(DEFAULT_PROPERTY_FILE_PATH);
-        } else {
-            logger.warn("No property file found, creating new: '" + DEFAULT_PROPERTY_FILE_PATH + "'.");
-            return new Properties();
-        }
-    }
-
-    private static final Map<String, String> mapArgs(String[] args) {
-
-        Map<String, String> argMap = new HashMap<>();
-
-        for (int i = 0; i < args.length; i++) {
-            String arg = args[i].toLowerCase();
-            if (arg.charAt(0) == '-') {
-                if (i == args.length - 1 || args[i + 1].charAt(0) == '-') {
-                    logger.warn("no value for option " + arg);
-                    break;
-                }
-                if (argMap.containsKey(arg))
-                    logger.warn("multiple uses of option " + arg);
-                if (!ARG_NAME_BY_ARG_ALIAS.containsKey(arg))
-                    logger.warn("unknown option " + arg);
-                String value = args[i + 1];
-                argMap.put(ARG_NAME_BY_ARG_ALIAS.get(arg), value);
-            }
-        }
-
-        return argMap;
     }
 }

--- a/src/main/java/org/iota/ict/utils/Properties.java
+++ b/src/main/java/org/iota/ict/utils/Properties.java
@@ -9,10 +9,11 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 /**
- * With instances of this class, the Ict and its sub-components can be easily configured. The properties can be read from
- * files or defined during runtime. Some properties might not be changeable yet after passing them to the Ict.
+ * With instances of this class, the Ict and its sub-components can be easily configured. The properties can be read from files or defined during runtime. Some
+ * properties might not be changeable yet after passing them to the Ict.
  *
  * @see org.iota.ict.Ict#Ict(Properties)
  */
@@ -43,6 +44,10 @@ public class Properties {
             ErrorHandler.handleError(logger, e, "Failed loading properties from file");
         }
         return new Properties(propObject);
+    }
+
+    public static Properties fromJavaProperties(java.util.Properties javaProperties) {
+        return new Properties(javaProperties);
     }
 
     public Properties() {
@@ -94,6 +99,30 @@ public class Properties {
         String hostString = address.substring(0, portColonIndex);
         int port = Integer.parseInt(address.substring(portColonIndex + 1, address.length()));
         return new InetSocketAddress(hostString, port);
+    }
+
+    public static java.util.Properties fromSystemProperties() {
+        java.util.Properties systemProperties = new java.util.Properties();
+        for (Property property : Property.values()) {
+            String valueOrNull = System.getProperty(property.name());
+            if(valueOrNull != null){
+                systemProperties.put(property.name(), valueOrNull);
+            }
+        }
+        return systemProperties;
+    }
+
+    public static java.util.Properties fromEnvironment() {
+        java.util.Properties environmentProperties = new java.util.Properties();
+        Map<String, String> envMap = System.getenv();
+        for (Property property : Property.values()) {
+            String upperCaseName = property.name();
+            String valueOrNull = envMap.get(upperCaseName);
+            if(valueOrNull != null){
+                environmentProperties.put(property.name(), valueOrNull);
+            }
+        }
+        return environmentProperties;
     }
 
     private String neighborsToString() {
@@ -155,7 +184,7 @@ public class Properties {
         }
     }
 
-    java.util.Properties toPropObject() {
+    public java.util.Properties toPropObject() {
         java.util.Properties propObject = new java.util.Properties();
         propObject.setProperty(Property.tangle_capacity.name(), tangleCapacity + "");
         propObject.setProperty(Property.anti_spam_rel.name(), antiSpamRel + "");
@@ -182,7 +211,7 @@ public class Properties {
         return this;
     }
 
-    private enum Property {
+    public enum Property {
         anti_spam_rel,
         anti_spam_abs,
         tangle_capacity,

--- a/src/test/java/org/iota/ict/MainCmdlineTest.java
+++ b/src/test/java/org/iota/ict/MainCmdlineTest.java
@@ -1,0 +1,173 @@
+package org.iota.ict;
+
+import org.iota.ict.utils.Properties;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Unit test for {@link org.iota.ict.Main.Cmdline}
+ */
+public class MainCmdlineTest {
+    private static final Map<String, Object> DEFAULT_PROPERTIES_MAP = new LinkedHashMap<>();
+
+    private final Main.Cmdline underTest = new Main.Cmdline();
+
+    @BeforeClass
+    public static void setupClass() {
+        Properties hardcoded = new Properties();
+        DEFAULT_PROPERTIES_MAP.put(Properties.Property.anti_spam_abs.name(), hardcoded.amtiSpamAbs);
+        DEFAULT_PROPERTIES_MAP.put(Properties.Property.anti_spam_rel.name(), hardcoded.antiSpamRel);
+        DEFAULT_PROPERTIES_MAP.put(Properties.Property.host.name(), hardcoded.host);
+        DEFAULT_PROPERTIES_MAP.put(Properties.Property.ixi_enabled.name(), hardcoded.ixiEnabled);
+        DEFAULT_PROPERTIES_MAP.put(Properties.Property.max_forward_delay.name(), hardcoded.maxForwardDelay);
+        DEFAULT_PROPERTIES_MAP.put(Properties.Property.min_forward_delay.name(), hardcoded.minForwardDelay);
+        DEFAULT_PROPERTIES_MAP.put(Properties.Property.name.name(), hardcoded.name);
+        DEFAULT_PROPERTIES_MAP.put(Properties.Property.neighbors.name(), hardcoded.neighbors.isEmpty() ? "" : hardcoded.neighbors.toString());
+        DEFAULT_PROPERTIES_MAP.put(Properties.Property.port.name(), hardcoded.port);
+        DEFAULT_PROPERTIES_MAP.put(Properties.Property.round_duration.name(), hardcoded.roundDuration);
+        DEFAULT_PROPERTIES_MAP.put(Properties.Property.spam_enabled.name(), hardcoded.spamEnabled);
+        DEFAULT_PROPERTIES_MAP.put(Properties.Property.tangle_capacity.name(), hardcoded.tangleCapacity);
+
+        // Check that default properties map contains all property keys
+        Properties.Property[] values = Properties.Property.values();
+        for (Properties.Property property : values) {
+            Assert.assertTrue("Expect property key '" + property.name() + "' not found in default test data.", DEFAULT_PROPERTIES_MAP.containsKey(property.name()));
+            Assert.assertNotNull("Expect a non null default test data value.", DEFAULT_PROPERTIES_MAP.get(property.name()));
+        }
+    }
+
+    @Test
+    public void when_parse_without_args_then_defaultValues_used() {
+        // when
+        Properties ictProperties = underTest.parse(new String[]{}).getIctProperties();
+
+        // then
+        assertProperties(DEFAULT_PROPERTIES_MAP, asMap(ictProperties.toPropObject()));
+    }
+
+    @Test
+    public void when_parse_without_args_and_systemProp_then_systemPropValue_used() {
+        // given
+        String key = Properties.Property.anti_spam_abs.name();
+        String expected = Long.toString(1001);
+        String expectedDefault = DEFAULT_PROPERTIES_MAP.get(key).toString();
+        Assert.assertNotEquals("Expected value for key '" + key + "' must differ for this test", expected, expectedDefault);
+
+        String resetPropertyOrNull = System.setProperty(key, expected);
+        try {
+            // when underTest is not init
+            Properties ictProperties = underTest.parse(new String[]{}).getIctProperties();
+
+            // then
+            String actual = ictProperties.toPropObject().getProperty(key);
+            Assert.assertEquals("Expected value for key '" + key + "' differ from default property value", expectedDefault, actual);
+
+            // when underTest is init
+            ictProperties = underTest.useSystemProperties()
+                    .parse(new String[]{}).getIctProperties();
+
+            // then
+            actual = ictProperties.toPropObject().getProperty(key);
+            Assert.assertEquals("Expected value for key '" + key + "' differ from system property value", expected, actual);
+        } finally {
+            if (resetPropertyOrNull != null) {
+                System.setProperty(key, resetPropertyOrNull);
+            }
+        }
+    }
+
+    @Test
+    public void when_parse_with_configArg_then_configPropValue_used() throws Exception {
+        String key = Properties.Property.anti_spam_abs.name();
+        String expected = Long.toString(1001);
+        String expectedDefault = DEFAULT_PROPERTIES_MAP.get(key).toString();
+        Assert.assertNotEquals("Expected value for key '" + key + "' must differ for this test", expected, expectedDefault);
+
+        Path config = Files.createTempFile("ict-", ".cfg");
+        Files.write(config, (key + "=" + expected + "\n").getBytes());
+
+        // when
+        Properties ictProperties = underTest.parse(new String[]{"--config", config.toString()}).getIctProperties();
+
+        // then
+        String actual = ictProperties.toPropObject().getProperty(key);
+        Assert.assertEquals("Expected value for key '" + key + "' differ from config-file property value", expected, actual);
+    }
+
+    @Test
+    public void when_parse_with_configArg_and_systemProp_then_systemPropValue_used() throws Exception {
+        // given
+        String key = Properties.Property.anti_spam_abs.name();
+        String expectedDefault = DEFAULT_PROPERTIES_MAP.get(key).toString();
+        String expectedConfig = Long.toString(1001);
+        Assert.assertNotEquals("Expected value for key '" + key + "' must differ for this test", expectedConfig, expectedDefault);
+
+        String expectedSystem = Long.toString(1002);
+        Assert.assertNotEquals("Expected value for key '" + key + "' must differ for this test", expectedSystem, expectedDefault);
+        Assert.assertNotEquals("Expected value for key '" + key + "' must differ for this test", expectedSystem, expectedConfig);
+
+        Path config = Files.createTempFile("ict-", ".cfg");
+        Files.write(config, (key + "=" + expectedConfig + "\n").getBytes());
+
+        String resetPropertyOrNull = System.setProperty(key, expectedSystem);
+        try {
+            // when underTest is not init
+            Properties ictProperties = underTest.parse(new String[]{"--config", config.toString()}).getIctProperties();
+
+            // then
+            String actual = ictProperties.toPropObject().getProperty(key);
+            Assert.assertEquals("Expected value for key '" + key + "' differ from config-file property value", expectedConfig, actual);
+
+            // when underTest is init
+            ictProperties = underTest.useSystemProperties()
+                    .parse(new String[]{}).getIctProperties();
+
+            // then
+            actual = ictProperties.toPropObject().getProperty(key);
+            Assert.assertEquals("Expected value for key '" + key + "' differ from system property value", expectedSystem, actual);
+        } finally {
+            if (resetPropertyOrNull != null) {
+                System.setProperty(key, resetPropertyOrNull);
+            }
+        }
+    }
+
+    @Test
+    public void when_parse_with_null_args_then_fail() {
+        try {
+            // when
+            underTest.parse(null);
+            Assert.fail("NPE expected if args = null");
+        } catch (Exception e) {
+            // then
+            Assert.assertTrue(e instanceof NullPointerException);
+            Assert.assertEquals("'args' must not be null.", e.getMessage());
+        }
+    }
+
+    /*
+     *********************
+     * Private test helper
+     *********************
+     */
+    private static Map<String, Object> asMap(java.util.Properties properties) {
+        LinkedHashMap<String, Object> map = new LinkedHashMap<>();
+        for (String key : properties.stringPropertyNames()) {
+            map.put(key.toString(), properties.getProperty(key));
+        }
+        return map;
+    }
+
+    private static void assertProperties(Map<String, Object> expectedMap, Map<String, Object> actualMap) {
+        for (Map.Entry<String, Object> entry : expectedMap.entrySet()) {
+            Assert.assertTrue("Expected key '" + entry.getKey() + "' not exist.", actualMap.containsKey(entry.getKey()));
+            Assert.assertEquals("Expected value differ for key '" + entry.getKey() + "'", entry.getValue().toString(), actualMap.get(entry.getKey()).toString());
+        }
+    }
+}


### PR DESCRIPTION
* enhance cmdline options 'ict [--config|--config-print|--config-create|--log-dir]'
* enable additional configuration layers (env, file, system)
* make 'log-dir' configurable (value is currently unused)

```
--help|-h           Print this help and exit
--config|-c FILE    Use this config 'FILE' (default: ./ict.cfg;if-exist)
                    - lookup first on environment for uppercase property keys
                    - and as last in system properties
--config-create     Create or overwrite './ict.cfg' file with parsed config
--config-print      Print parsed config and exit

--log-dir DIR       Write logs to existing DIR (default: logs/;currently unused)
```