### PR TITLE
ict: improve tangle concurrency - make transaction-deletion thread safe

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,8 @@ repositories {
 }
 
 dependencies {
-    compile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile "org.mockito:mockito-core:2.+"
 
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.1'

--- a/src/test/java/org/iota/ict/model/TangleTest.java
+++ b/src/test/java/org/iota/ict/model/TangleTest.java
@@ -1,0 +1,151 @@
+package org.iota.ict.model;
+
+import org.iota.ict.Ict;
+import org.iota.ict.utils.Trytes;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ConcurrentModificationException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Unit test for {@link Tangle}
+ */
+public class TangleTest {
+    private final Ict ictMock = Mockito.mock(Ict.class);
+
+    private final Tangle underTest = new Tangle(ictMock);
+
+    @Test
+    public void when_construct_with_nullIct_then_throw_NPE() {
+        try {
+            new Tangle(null);
+            Assert.fail("NPE (\"'ict' must not null\") expected.");
+        } catch (Exception e) {
+            Assert.assertTrue(e instanceof NullPointerException);
+            Assert.assertEquals("'ict' must not null", e.getMessage());
+        }
+    }
+
+    @Test
+    public void when_findTransactionByAddress_then_sameCreatedTransaction_expected() {
+        // given
+        Transaction expected = randomTransaction();
+
+        // when
+        underTest.createTransactionLogIfAbsent(expected);
+
+        //then
+        Set<Transaction> actual = underTest.findTransactionsByAddress(expected.address);
+        assertThatTransactionContainedInSet(expected, actual);
+    }
+
+    @Test
+    public void when_remove_transaction_concurrently_no_error_occur() throws InterruptedException {
+        // given
+        final int transactionCountWhereConcurrentAccessExpected = 200;
+        final String transactionsForAddress = Trytes.randomSequenceOfLength(81);
+        final Set<Transaction> transactionSet = createRandomTransactionsForOneAddress(transactionCountWhereConcurrentAccessExpected, transactionsForAddress);
+        final AtomicBoolean concurrentModifcationObserver = new AtomicBoolean(false);
+
+        // when
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                while (true) {
+                    try {
+                        Set<Transaction> currentSet = underTest.findTransactionsByAddress(transactionsForAddress);
+                        System.out.println("Found " + currentSet.size() + " transactions for transactionsForAddress " + transactionsForAddress);
+
+                        safeSleep(13);
+                    } catch (ConcurrentModificationException e) {
+                        System.err.println("\n>>>> D E T E C T - " + e.getClass() + " cause " + e.getMessage() + "\n");
+                        concurrentModifcationObserver.set(true);
+                        e.printStackTrace();
+                        break;
+                    }
+                }
+            }
+        }, "Break-on-first-conccurent-exception-thread").start();
+
+        final CountDownLatch blocksUntilAllTransactionsRemoved = new CountDownLatch(1);
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                for (Transaction aTransactionSet : transactionSet) {
+                    try {
+                        Transaction next = aTransactionSet;
+                        System.out.print("Start deleting of transaction " + next.hash + " ... ");
+                        underTest.deleteTransaction(next);
+                        System.out.println(" successful deleted " + next.hash);
+
+                        safeSleep(7);
+                    } catch (Exception e) {
+                        // Should never occur
+                        e.printStackTrace();
+                    }
+                }
+                blocksUntilAllTransactionsRemoved.countDown();
+            }
+        },"Delete-all-transactions-thread").start();
+
+        blocksUntilAllTransactionsRemoved.await();
+        // then check concurrent access
+        // - its no 100 % test case because the test can also success in error case.
+        // - it depends if the test threads really access the transaction-list at the same time
+        Assert.assertFalse("Expect no concurrent modification exception.", concurrentModifcationObserver.get());
+    }
+
+    /*
+     *************************************
+     * Private helper
+     *************************************
+     */
+
+    private Set<Transaction> createRandomTransactionsForOneAddress(int transactionCountWhereCunncurrentExceptionAlwaysOccure, String address) {
+        final Set<Transaction> transactions = randomSetOfTransactionsForTheSameAddress(transactionCountWhereCunncurrentExceptionAlwaysOccure, address);
+        for (Transaction transaction : transactions) {
+            underTest.createTransactionLogIfAbsent(transaction);
+        }
+        final Set<Transaction> actualSet = underTest.findTransactionsByAddress(address);
+        Assert.assertEquals(transactions.size(), actualSet.size());
+        return actualSet;
+    }
+
+    private static void safeSleep(int millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static Transaction randomTransaction() {
+        TransactionBuilder builder = new TransactionBuilder();
+        builder.address = Trytes.randomSequenceOfLength(81);
+        Transaction transaction = builder.build();
+        return transaction;
+    }
+
+    private static Set<Transaction> randomSetOfTransactionsForTheSameAddress(int size, String address) {
+        final TransactionBuilder builder = new TransactionBuilder();
+        builder.address = address;
+
+        LinkedHashSet<Transaction> randomSet = new LinkedHashSet<>();
+        for (int i = 0; i < size; i++) {
+            builder.asciiMessage("Ascii message " + i);
+            randomSet.add(builder.build());
+        }
+        return randomSet;
+    }
+
+    private static Set<Transaction> assertThatTransactionContainedInSet(Transaction expected, Set<Transaction> actual) {
+        Assert.assertNotNull("Expect not null transaction result set.", actual);
+        Assert.assertTrue("Expect same created transaction instance", actual.contains(expected));
+        return actual;
+    }
+}


### PR DESCRIPTION
There was a possible concurrent problem in Tangle class.

* The underlying  `HashSet` can be raise a `ConcurrentModificationException` 
* I moved internal `HashSet` use to `CopyOnWriteArrayList` (i guess it's the simplest solution)
* The public Tangle interface is untouched.
