### PR TITLE
TransactionBuilder should padRight the tag field

### DIFF
--- a/src/main/java/org/iota/ict/model/transaction/Transaction.java
+++ b/src/main/java/org/iota/ict/model/transaction/Transaction.java
@@ -100,7 +100,7 @@ public class Transaction {
         bundleNonce = builder.bundleNonce;
         trunkHash = builder.trunkHash;
         branchHash = builder.branchHash;
-        tag = builder.tag;
+        tag = Trytes.padRight(builder.tag,Transaction.Field.TAG.tryteLength);
         attachmentTimestamp = builder.attachmentTimestamp;
         attachmentTimestampLowerBound = builder.attachmentTimestampLowerBound;
         attachmentTimestampUpperBound = builder.attachmentTimestampUpperBound;

--- a/src/test/java/org/iota/ict/model/transaction/TransactionTest.java
+++ b/src/test/java/org/iota/ict/model/transaction/TransactionTest.java
@@ -33,6 +33,15 @@ public class TransactionTest {
     }
 
     @Test
+    public void testTransactionBuilderPadRightTAG() {
+        TransactionBuilder builder = new TransactionBuilder();
+        builder.tag = "UNICORN9FOR9PRESIDENT";
+        Transaction transaction = builder.build();
+        Assert.assertEquals(transaction.address(), builder.address);
+        Assert.assertEquals(transaction.tag(), "UNICORN9FOR9PRESIDENT999999");
+    }
+
+    @Test
     public void testTransactionEncodingDecoding() {
         Transaction original = new Transaction(Trytes.toBytes(TRYTES_VALID_FLAGS));
         Transaction copy = new Transaction(Trytes.toBytes(original.decodeBytesToTrytes()+Trytes.padRight("", 81)));

--- a/src/test/java/org/iota/ict/model/transaction/TransactionTest.java
+++ b/src/test/java/org/iota/ict/model/transaction/TransactionTest.java
@@ -37,7 +37,6 @@ public class TransactionTest {
         TransactionBuilder builder = new TransactionBuilder();
         builder.tag = "UNICORN9FOR9PRESIDENT";
         Transaction transaction = builder.build();
-        Assert.assertEquals(transaction.address(), builder.address);
         Assert.assertEquals(transaction.tag(), "UNICORN9FOR9PRESIDENT999999");
     }
 


### PR DESCRIPTION
This simple code fails because builder.tag field is less than 27 trytes
```
TransactionBuilder builder = new TransactionBuilder();
builder.tag = "SHORT9TAG";
Transaction transaction = builder.build();
```
Suggestion: transactionBuilder should add the missing trytes (right pad with '9')