### PR TITLE
 Tangle.findTransactionBy... thread safety issue

### DIFF
--- a/src/main/java/org/iota/ict/model/tangle/Tangle.java
+++ b/src/main/java/org/iota/ict/model/tangle/Tangle.java
@@ -52,13 +52,15 @@ public class Tangle implements PropertiesUser {
     }
 
     public Transaction findTransactionByHash(String hash) {
-        return transactionsByHash.containsKey(hash) ? transactionsByHash.get(hash).transaction : null;
+        Tangle.TransactionLog log = transactionsByHash.get(hash);
+        return log!=null ? log.transaction : null;
     }
 
     public Set<Transaction> findTransactionsByAddress(String address) {
         Set<Transaction> transactions = new HashSet<>();
-        if (transactionsByAddress.containsKey(address)) {
-            for (TransactionLog log : transactionsByAddress.get(address))
+        List<Tangle.TransactionLog> txByAddress = transactionsByAddress.get(address);
+        if (txByAddress!=null) {
+            for (TransactionLog log : txByAddress)
                 transactions.add(log.transaction);
         }
         return transactions;
@@ -66,8 +68,9 @@ public class Tangle implements PropertiesUser {
 
     public Set<Transaction> findTransactionsByTag(String tag) {
         Set<Transaction> transactions = new HashSet<>();
-        if (transactionsByTag.containsKey(tag)) {
-            for (TransactionLog log : transactionsByTag.get(tag))
+        List<Tangle.TransactionLog> txByTag = transactionsByTag.get(tag);
+        if (txByTag!=null) {
+            for (TransactionLog log : txByTag)
                 transactions.add(log.transaction);
         }
         return transactions;

--- a/src/test/java/org/iota/ict/model/tangle/TangleTest.java
+++ b/src/test/java/org/iota/ict/model/tangle/TangleTest.java
@@ -15,12 +15,9 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.junit.Assert.fail;
-
 /**
  * Unit test for {@link Tangle}
  */
-@Ignore // Test occasionally. Takes too long.
 public class TangleTest {
     private final Ict ictMock = Mockito.mock(Ict.class);
 
@@ -30,7 +27,7 @@ public class TangleTest {
     public void when_construct_with_nullIct_then_throw_NPE() {
         try {
             new Tangle(null);
-            fail("NPE (\"'ict' must not null\") expected.");
+            Assert.fail("NPE (\"'ict' must not null\") expected.");
         } catch (Exception e) {
             Assert.assertTrue(e instanceof NullPointerException);
             Assert.assertEquals("'ict' must not null", e.getMessage());
@@ -51,6 +48,7 @@ public class TangleTest {
     }
 
     @Test
+    @Ignore // Test occasionally. Takes too long.
     public void when_remove_transaction_concurrently_no_error_occur() throws InterruptedException {
         // given
         final int transactionCountWhereConcurrentAccessExpected = 200;
@@ -82,7 +80,8 @@ public class TangleTest {
             public void run() {
                 for (Transaction aTransactionSet : transactionSet) {
                     try {
-                        underTest.deleteTransaction(aTransactionSet);
+                        Transaction next = aTransactionSet;
+                        underTest.deleteTransaction(next);
 
                         safeSleep(7);
                     } catch (Exception e) {
@@ -125,7 +124,6 @@ public class TangleTest {
                     } catch (Exception e) {
                         e.printStackTrace();
                         exceptionOccurred.set(true);
-                        fail("findTransactionsByAddress should never throw an exception");
                         break;
                     }
                 }
@@ -157,7 +155,7 @@ public class TangleTest {
 
         blocksUntilAllTransactionsRemoved.await();
         if(exceptionOccurred.get()){
-            fail("findTransactionsByAddress should not fail");
+            Assert.fail("findTransactionsByAddress should not fail");
         }
     }
 


### PR DESCRIPTION
There is a concurrency issue when deleting a transaction and executing findTransactionByXYZ in parallel.  Bug is caused by this code pattern :

```
if(map.containsKey(k)){   //may be true
    for(TransactionLog log:map.get(k)){   //map.get(k) may be null when entry 'k' was deleted between both instructions.
        ...
    }
}

```
This pull request contains a new test demonstrating the bug and the required fixes.
(it also un-ignore TangleTest)