### PR TITLE
fix #73 (Wrong slf4j binding)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,15 +16,10 @@ repositories {
 dependencies {
     compile "com.sparkjava:spark-core:2.7.2"
     compile 'org.json:json:20171018'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.1'
+    compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.1"
 
     // used until pull request for iotaledger/iota.curl.java is merged
     compile 'com.github.mikrohash:iota.curl.java:master'
-
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.1'
-
-    // to prevent warning: https://www.slf4j.org/codes.html#StaticLoggerBinder
-    compile group: 'org.slf4j', name: 'slf4j-nop', version: '1.7.25'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'pl.pragmatists', name: 'JUnitParams', version: '1.1.1'


### PR DESCRIPTION
We should use the binding for log4j2 : log4j-slf4j-impl 