### PR TITLE
fix #75 (gradle 5 transitive dependency inclusion)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     compile "com.sparkjava:spark-core:2.7.2"
     compile 'org.json:json:20171018'
     compile "org.apache.logging.log4j:log4j-slf4j-impl:2.11.1"
+    compile "org.apache.logging.log4j:log4j-core:2.11.1"
 
     // used until pull request for iotaledger/iota.curl.java is merged
     compile 'com.github.mikrohash:iota.curl.java:master'


### PR DESCRIPTION
log4j use maven and gradle 5 introduce changes in the way transitive dependencies from maven are included in classpath. Solution is to explicitly include the transitive dependency.